### PR TITLE
Fix TTT shape mismatch

### DIFF
--- a/rwkv7_ttt_phantom.py
+++ b/rwkv7_ttt_phantom.py
@@ -308,10 +308,11 @@ class RWKV7TimeMixing(nn.Module):
                 core_dim = min(self.core_dim, state.size(-1))
                 if core_dim > 0:
                     core_state = state[:, :, :core_dim, :core_dim].clone()
-                    core_state_flat = core_state.view(B, -1)
+                    # summarize matrix state to a vector per batch for TTT
+                    core_state_vec = core_state.mean(dim=3).mean(dim=1)
                     target = v_core[:, t, :core_dim].detach()
-                    core_state_flat = self.ttt(core_state_flat, target.view(B, -1))
-                    state[:, :, :core_dim, :core_dim] = core_state_flat.view(
+                    core_state_vec = self.ttt(core_state_vec, target.view(B, -1))
+                    state[:, :, :core_dim, :core_dim] = core_state_vec[:, None, :, None].expand(
                         B, H, core_dim, core_dim
                     )
 


### PR DESCRIPTION
## Summary
- fix vector shape used for test-time training to avoid matmul mismatch

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_687da09aea1c8323b57ca9c9887e70fb