### PR TITLE
Fix GroupNorm input layout

### DIFF
--- a/rwkv7_ttt_phantom.py
+++ b/rwkv7_ttt_phantom.py
@@ -331,7 +331,9 @@ class RWKV7TimeMixing(nn.Module):
         output = output.view(B, T, C)
 
         # Apply group norm and final processing
+        output = output.permute(0, 2, 1)  # [B, C, T]
         output = self.ln_x(output)
+        output = output.permute(0, 2, 1)
         output = output + (r * k * self.r_k.unsqueeze(0).unsqueeze(0)).view(
             B, T, H, N
         ).sum(dim=-1, keepdim=True).expand(-1, -1, -1, N).contiguous().view(


### PR DESCRIPTION
## Summary
- fix group norm layout in `RWKV7TimeMixing`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687daa7357f48323af016738167911ea