### PR TITLE
Fix optimizer warmup for lightning

### DIFF
--- a/Training.py
+++ b/Training.py
@@ -269,7 +269,10 @@ class RWKV7PhantomLightning(pl.LightningModule):
             lr_scale = min(
                 1.0, float(self.trainer.global_step + 1) / float(self.warmup_steps)
             )
-            for pg in self.optimizers()[0].param_groups:
+            optimizer = self.optimizers()
+            if isinstance(optimizer, list):
+                optimizer = optimizer[0]
+            for pg in optimizer.param_groups:
                 pg["lr"] = lr_scale * self.learning_rate
 
         super().optimizer_step(*args, **kwargs)

--- a/rwkv7_ttt_phantom.py
+++ b/rwkv7_ttt_phantom.py
@@ -314,8 +314,9 @@ class RWKV7TimeMixing(nn.Module):
                     core_state_vec = core_state.mean(dim=3).mean(dim=1)
                     target = v_core[:, t, :core_dim].detach()
                     core_state_vec = self.ttt(core_state_vec, target.view(B, -1))
-                    state[:, :, :core_dim, :core_dim] = core_state_vec[:, None, :, None].expand(
-                        B, H, core_dim, core_dim
+                    state[:, :, :core_dim, :core_dim] = (
+                        core_state_vec[:, None, :, None]
+                        .expand(B, H, core_dim, core_dim)
                     )
 
             # RWKV-7 state update with generalized delta rule


### PR DESCRIPTION
## Summary
- handle single optimizer properly in `optimizer_step`
- wrap long line in phantom model for flake8

## Testing
- `flake8`
- `bandit -r . -ll`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_687daf61784c8323a4591bcb1b9db62c