### PR TITLE
Fix ChannelMixing state shape

### DIFF
--- a/rwkv7_ttt_phantom.py
+++ b/rwkv7_ttt_phantom.py
@@ -381,7 +381,9 @@ class RWKV7ChannelMixing(nn.Module):
         k = torch.relu(k) ** 2
         output, _ = self.value(k)
 
-        return output, x
+        # Only keep the last token as the new previous input to avoid
+        # dimension mismatch when sequence lengths change across calls.
+        return output, x[:, -1]
 
 
 class RWKV7Block(nn.Module):


### PR DESCRIPTION
## Summary
- return only the last token from `RWKV7ChannelMixing.forward`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687db1b474c48323ad60c02727469b6d